### PR TITLE
Eliminada una de las dos ejecuciones de los test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 before_script:
   - psql -U postgres -c "create database yourney_db owner postgres"
 script:
-  - mvn test -B
   - mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
 notifications:
   email:


### PR DESCRIPTION
Se ha corregido un fallo en la configuración del fichero de configuración que realiza las pruebas en dos ocasiones en la plataforma de Integración continua Travis CI.

Tarea asociada: #23