### PR TITLE
Añadido estado de itinerario a DTO y eliminada condición innecesaria

### DIFF
--- a/src/main/java/com/yourney/controller/ActivityController.java
+++ b/src/main/java/com/yourney/controller/ActivityController.java
@@ -160,11 +160,6 @@ public class ActivityController {
 
         Activity activityToDelete = foundActivity.get();
 
-        if (!activityToDelete.getItinerary().getStatus().equals(StatusType.PUBLISHED)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body("La actividad se encuentra publicada en este momento y por tanto no se puede borrar.");
-        }
-
         if (!username.equals(activityToDelete.getItinerary().getAuthor().getUsername())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(new Message("No puede eliminar una actividad de un itinerario del que no es creador."));

--- a/src/main/java/com/yourney/model/dto/ItineraryDto.java
+++ b/src/main/java/com/yourney/model/dto/ItineraryDto.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import com.yourney.model.SeasonType;
+import com.yourney.model.StatusType;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -34,5 +35,7 @@ public class ItineraryDto {
     private LocalDateTime createDate;
 
     private SeasonType recommendedSeason;
+
+    private StatusType status;
 
 }

--- a/src/main/java/com/yourney/model/projection/ItineraryProjection.java
+++ b/src/main/java/com/yourney/model/projection/ItineraryProjection.java
@@ -1,5 +1,7 @@
 package com.yourney.model.projection;
 
+import com.yourney.model.StatusType;
+
 public interface ItineraryProjection {
 
     Long getId();
@@ -15,4 +17,6 @@ public interface ItineraryProjection {
     String getUsername();
 
     Double getBudget();
+
+    StatusType getStatus();
 }


### PR DESCRIPTION
Añadido estado de itinerario a su DTO y proyección y eliminada condición innecesaria para eliminar una actividad, que impedía su correcto funcionamiento.

Tarea: #60
Co-Authored-By: Alejandro Sánchez Saavedra <48711075+alesansaa@users.noreply.github.com>
Co-Authored-By: Antonio Suárez Bono <48652527+antsuabon@users.noreply.github.com>