### PR TITLE
Aumento de límite de capacidad de persistencia para parámetros específicos

### DIFF
--- a/src/main/java/com/yourney/model/Landmark.java
+++ b/src/main/java/com/yourney/model/Landmark.java
@@ -34,12 +34,12 @@ public class Landmark {
 
 	@NotBlank
 	@Column(nullable = false)
-	@Length(max = 100)
+	@Length(max = 50)
 	private String name;
 
 	@NotBlank
 	@Column(nullable = false)
-	@Length(max = 255)
+	@Length(max = 1000)
 	private String description;
 
 	@Range(min = 0)

--- a/src/main/java/com/yourney/model/dto/ActivityDto.java
+++ b/src/main/java/com/yourney/model/dto/ActivityDto.java
@@ -4,6 +4,8 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.constraints.Length;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -14,9 +16,11 @@ public class ActivityDto {
 	private Long id;
 
 	@NotBlank(message = "El campo nombre es obligatorio")
+	@Length(max = 50, message = "El tamaño del campo título es demasiado largo, y el máximo son 50 caracteres.")
 	private String title;
 
 	@NotBlank(message = "El campo nombre es obligatorio")
+	@Length(max = 1000, message = "El tamaño del campo descripción es demasiado largo, y el máximo son 1000 caracteres.")
 	private String description;
 
 	@NotNull(message = "El campo días estimados es obligatorio")

--- a/src/main/java/com/yourney/model/dto/CommentDto.java
+++ b/src/main/java/com/yourney/model/dto/CommentDto.java
@@ -5,6 +5,8 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.constraints.Length;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -16,6 +18,7 @@ public class CommentDto {
     private Long itinerary;
 
     @NotBlank(message = "El campo contenido es obligatorio")
+    @Length(max = 1000, message = "El tamaño del campo descripción es demasiado largo, y el máximo son 1000 caracteres.")
     private String content;
 
     @NotNull(message = "El campo puntuación es obligatorio")

--- a/src/main/java/com/yourney/model/dto/ItineraryDto.java
+++ b/src/main/java/com/yourney/model/dto/ItineraryDto.java
@@ -9,6 +9,8 @@ import javax.validation.constraints.NotNull;
 import com.yourney.model.SeasonType;
 import com.yourney.model.StatusType;
 
+import org.hibernate.validator.constraints.Length;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -19,9 +21,11 @@ public class ItineraryDto {
     private long id;
 
     @NotBlank(message = "El campo nombre es obligatorio")
+    @Length(max = 50, message = "El tamaño del campo nombre es demasiado largo, y el máximo son 50 caracteres.")
     private String name;
 
     @NotBlank(message = "El campo descripción es obligatorio")
+    @Length(max = 1000, message = "El tamaño del campo descripción es demasiado largo, y el máximo son 1000 caracteres.")
     private String description;
 
     @NotNull(message = "El campo presupuesto es obligatorio")

--- a/src/main/java/com/yourney/model/dto/LandmarkDto.java
+++ b/src/main/java/com/yourney/model/dto/LandmarkDto.java
@@ -20,11 +20,11 @@ public class LandmarkDto {
     private Long id;
 
     @NotBlank(message = "El campo nombre es obligatorio")
-    @Length(max = 100)
+    @Length(max = 50, message = "El tamaño del campo nombre es demasiado largo, y el máximo son 50 caracteres.")
     private String name;
 
     @NotBlank(message = "El campo nombre es obligatorio")
-    @Length(max = 255)
+    @Length(max = 1000, message = "El tamaño del campo descripción es demasiado largo, y el máximo son 1000 caracteres.")
     private String description;
 
     @Min(value = 0, message = "El precio mínimo es 0")
@@ -36,10 +36,10 @@ public class LandmarkDto {
     @NotBlank(message = "El campo ciudad es obligatorio")
     private String city;
     
-    @Range(min = -90, max = 90)
+    @Range(min = -90, max = 90, message = "La latitud debe encontrarse entre -90 y 90")
     private Double latitude;
 
-    @Range(min = -180, max = 180)
+    @Range(min = -180, max = 180, message = "La longitud debe encontrarse entre -180 y 180")
     private Double longitude;
 
     private String category;
@@ -47,7 +47,7 @@ public class LandmarkDto {
     @Email
     private String email;
 
-    @Length(max = 50)
+    @Length(max = 50, message = "El campo teléfono es demasiado largo")
     private String phone;
 
     @URL(message = "El campo website se trata de una URL")


### PR DESCRIPTION
Tras haber detectado una deficiencia de carácter grave en la aplicación, que permitía generar texto de forma ilimitada, y no persistir los cambios por exceder un límite, hemos decidido aumentar el límite de persistencia para los valores de nombre, título y descripción de las entidades Itinerario, Landmark y Actividad. 

Finalmente, se han fijado 50 para campos de título, y 1000 de descripción.

Añadido límite para el campo descripción del comentario, con 1000 caracteres como máximo, así como una descripción del error.

Tarea relacionada: #106 

