### PR TITLE
Corrección de malos olores en las pruebas y añadido soporte para búsquedas en minúscula

### DIFF
--- a/src/main/java/com/yourney/repository/LandmarkRepository.java
+++ b/src/main/java/com/yourney/repository/LandmarkRepository.java
@@ -16,7 +16,7 @@ public interface LandmarkRepository extends CrudRepository<Landmark, Long> {
     @Query("select distinct l.country from Landmark l order by country")
     Iterable<String> findAllCountries();
 
-    @Query("select distinct l.city from Landmark l where l.country=:name order by city")
+    @Query("select distinct l.city from Landmark l where LOWER(l.country)=LOWER(:name) order by city")
     Iterable<String> findCitiesByCountry(@Param("name") String name);
 
     @Query("select distinct l.city from Landmark l order by city")
@@ -25,6 +25,6 @@ public interface LandmarkRepository extends CrudRepository<Landmark, Long> {
     @Query("select case when count(ac)> 0 then true else false end from Activity ac where ac.landmark.id=:id")
     Boolean existsActivityByLandmarkId(Long id);
 
-    @Query("select l.id as id, l.name as name, l.description as description, l.price as price, l.country as country, l.city as city, l.latitude as latitude, l.longitude as longitude, l.endPromotionDate as endPromotionDate, l.category as category, l.email as email, l.phone as phone, l.website as website, l.instagram as instagram, l.twitter as twitter, l.createDate as createDate, l.views as views, l.image as image, l.imageUrl as imageUrl, l.endPromotionDate >= CURRENT_DATE as p from Landmark l where l.country like :country and l.city like :city and l.name like :name order by p, l.views desc")
+    @Query("select l.id as id, l.name as name, l.description as description, l.price as price, l.country as country, l.city as city, l.latitude as latitude, l.longitude as longitude, l.endPromotionDate as endPromotionDate, l.category as category, l.email as email, l.phone as phone, l.website as website, l.instagram as instagram, l.twitter as twitter, l.createDate as createDate, l.views as views, l.image as image, l.imageUrl as imageUrl, l.endPromotionDate >= CURRENT_DATE as p from Landmark l where LOWER(l.country) like LOWER(:country) and LOWER(l.city) like LOWER(:city) and LOWER(l.name) like LOWER(:name) order by p, l.views desc")
     Page<LandmarkProjection> searchByProperties(String country, String city, String name, Pageable pageable);
 }

--- a/src/test/java/com/yourney/model/ActivityDtoModelTests.java
+++ b/src/test/java/com/yourney/model/ActivityDtoModelTests.java
@@ -106,7 +106,7 @@ class ActivityDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(ActivityDto.class).verify();
 	}
 
@@ -128,6 +128,6 @@ class ActivityDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(a1.toString(),"");
+		assertNotEquals("",a1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/AuthorDtoModelTests.java
+++ b/src/test/java/com/yourney/model/AuthorDtoModelTests.java
@@ -39,13 +39,13 @@ class AuthorDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsAuthorClass() {
+	void testEqualsAuthorClass() {
 		EqualsVerifier.simple().forClass(AuthorDto.class).verify();
 	}
 
 
 	@Test
-	public void testEqualsPrincipalUserClass() {
+	void testEqualsPrincipalUserClass() {
 		EqualsVerifier.simple().forClass(PrincipalUser.class).verify();
 	}
 
@@ -66,6 +66,6 @@ class AuthorDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(a1.toString(),"");
+		assertNotEquals("",a1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/CommentDtoModelTests.java
+++ b/src/test/java/com/yourney/model/CommentDtoModelTests.java
@@ -37,7 +37,7 @@ class CommentDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(CommentDto.class).verify();
 	}
 
@@ -49,7 +49,7 @@ class CommentDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(c1.toString(),"");
-		assertNotEquals(c2.toString(),"");
+		assertNotEquals("",c1.toString());
+		assertNotEquals("",c2.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/ImageDtoModelTests.java
+++ b/src/test/java/com/yourney/model/ImageDtoModelTests.java
@@ -28,12 +28,12 @@ class ImageDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(ImageDto.class).verify();
 	}
 
 	@Test
-	public void testEqualsImageClass() {
+	void testEqualsImageClass() {
 		EqualsVerifier.simple().forClass(Image.class).withIgnoredAnnotations(Id.class).verify();
 		i1.toString();
 		i1.hashCode();
@@ -46,6 +46,6 @@ class ImageDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(s1.toString(),"");
+		assertNotEquals("",s1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/ItineraryDtoModelTests.java
+++ b/src/test/java/com/yourney/model/ItineraryDtoModelTests.java
@@ -104,27 +104,27 @@ class ItineraryDtoModelTests {
 	}
 	
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(ItineraryDto.class).verify();
 	}
 
 	@Test
-	public void testEqualsLandmarkClass() {
+	void testEqualsLandmarkClass() {
 		EqualsVerifier.simple().withPrefabValues(Itinerary.class, it1, it2).forClass(Landmark.class).withIgnoredAnnotations(Id.class).verify();
 	}
 
 	@Test
-	public void testEqualsCommentClass() {
+	void testEqualsCommentClass() {
 		EqualsVerifier.simple().withPrefabValues(Itinerary.class, it1, it2).forClass(Comment.class).withIgnoredAnnotations(Id.class).verify();
 	}	
 
 	@Test
-	public void testEqualsItineraryClass() {
+	void testEqualsItineraryClass() {
 		EqualsVerifier.simple().withPrefabValues(Activity.class, ac1, ac2).withPrefabValues(Comment.class, c1, c2).forClass(Itinerary.class).withIgnoredAnnotations(Id.class).verify();
 	}	
 
 	@Test
-	public void testEqualsActivityClass() {
+	void testEqualsActivityClass() {
 		EqualsVerifier.simple().withPrefabValues(Activity.class, ac1, ac2).withPrefabValues(Itinerary.class, it1, it2).forClass(Activity.class).withIgnoredAnnotations(Id.class).verify();
 	}	
 	
@@ -145,6 +145,6 @@ class ItineraryDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(l1.toString(),"");
+		assertNotEquals("",l1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/LandmarkDtoModelTests.java
+++ b/src/test/java/com/yourney/model/LandmarkDtoModelTests.java
@@ -49,7 +49,7 @@ class LandmarkDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(LandmarkDto.class).verify();
 	}
 
@@ -65,6 +65,6 @@ class LandmarkDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(l1.toString(),"");
+		assertNotEquals("",l1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/MessageDtoModelTests.java
+++ b/src/test/java/com/yourney/model/MessageDtoModelTests.java
@@ -21,7 +21,7 @@ class MessageDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(Message.class).verify();
 	}
 
@@ -32,6 +32,6 @@ class MessageDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(m1.toString(),"");
+		assertNotEquals("",m1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/SearchDtoModelTests.java
+++ b/src/test/java/com/yourney/model/SearchDtoModelTests.java
@@ -22,7 +22,7 @@ class SearchDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(Search.class).verify();
 	}
 
@@ -33,6 +33,6 @@ class SearchDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(s1.toString(),"");
+		assertNotEquals("",s1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/SeasonDtoModelTests.java
+++ b/src/test/java/com/yourney/model/SeasonDtoModelTests.java
@@ -20,7 +20,7 @@ class SeasonDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(SeasonDto.class).verify();
 	}
 
@@ -31,6 +31,6 @@ class SeasonDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(s1.toString(),"");
+		assertNotEquals("",s1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/security/JwtDtoModelTests.java
+++ b/src/test/java/com/yourney/model/security/JwtDtoModelTests.java
@@ -27,7 +27,7 @@ class JwtDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(JwtDto.class).verify();
 	}
 
@@ -38,6 +38,6 @@ class JwtDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(c1.toString(),"");
+		assertNotEquals("",c1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/security/LoginUserDtoModelTests.java
+++ b/src/test/java/com/yourney/model/security/LoginUserDtoModelTests.java
@@ -21,7 +21,7 @@ class LoginUserDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(LoginUser.class).verify();
 	}
 
@@ -32,6 +32,6 @@ class LoginUserDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(m1.toString(),"");
+		assertNotEquals("",m1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/security/NewUserDtoModelTests.java
+++ b/src/test/java/com/yourney/model/security/NewUserDtoModelTests.java
@@ -23,7 +23,7 @@ class NewUserDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(NewUser.class).verify();
 	}
 
@@ -34,6 +34,6 @@ class NewUserDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(m1.toString(),"");
+		assertNotEquals("", m1.toString());
 	}
 }

--- a/src/test/java/com/yourney/model/security/UpdateUserDtoModelTests.java
+++ b/src/test/java/com/yourney/model/security/UpdateUserDtoModelTests.java
@@ -64,7 +64,7 @@ class UpdateUserDtoModelTests {
 	}
 
 	@Test
-	public void testEqualsClass() {
+	void testEqualsClass() {
 		EqualsVerifier.simple().forClass(UpdateUser.class).verify();
 	}
 
@@ -75,8 +75,8 @@ class UpdateUserDtoModelTests {
 
 	@Test
 	void testToString() {
-		assertNotEquals(ro1.toString(),"");
-		assertNotEquals(pu1.toString(),"");
-		assertNotEquals(m1.toString(),"");
+		assertNotEquals("",ro1.toString());
+		assertNotEquals("",pu1.toString());
+		assertNotEquals("",m1.toString());
 	}
 }

--- a/src/test/java/com/yourney/service/ActivityServiceTests.java
+++ b/src/test/java/com/yourney/service/ActivityServiceTests.java
@@ -3,6 +3,7 @@ package com.yourney.service;
 
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDateTime;
@@ -204,7 +205,7 @@ class ActivityServiceTests {
 		List<Activity> result = new ArrayList<Activity>();
 		expected.forEach(result::add);
 
-		assertTrue(result.size() == 4);
+		assertEquals(4,result.size());
 		assertSame(result.get(0), this.a1);
 		assertSame(result.get(1), this.a2);
 		assertSame(result.get(2), this.a3);
@@ -234,7 +235,7 @@ class ActivityServiceTests {
 		List<Activity> result = new ArrayList<Activity>();
 		expected.forEach(result::add);
 
-		assertTrue(result.size() == 2);
+		assertEquals(2,result.size());
 		assertSame(result.get(0), this.a2);
 		assertSame(result.get(1), this.a3);
 	}
@@ -246,7 +247,7 @@ class ActivityServiceTests {
 		List<Activity> result = new ArrayList<Activity>();
 		expected.forEach(result::add);
 
-		assertTrue(result.size() == 3);
+		assertEquals(3,result.size());
 		assertSame(result.get(0), this.a1);
 		assertSame(result.get(1), this.a2);
 		assertSame(result.get(2), this.a3);

--- a/src/test/java/com/yourney/service/ItineraryServiceTests.java
+++ b/src/test/java/com/yourney/service/ItineraryServiceTests.java
@@ -1,6 +1,7 @@
 
 package com.yourney.service;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
@@ -254,7 +255,7 @@ class ItineraryServiceTests {
 		List<Itinerary> result = new ArrayList<Itinerary>();
 		expected.forEach(result::add);
 
-		assertTrue(result.size() == 2);
+		assertEquals(2,result.size());
 		assertSame(result.get(0), this.it1);
 		assertSame(result.get(1), this.it2);
 	}
@@ -263,41 +264,41 @@ class ItineraryServiceTests {
 	void testSearchByProperties() {
 		Page<ItineraryProjection> expected = this.itineraryService.searchByProperties(TEST_ITINERARY_COUNTRY_1, TEST_ITINERARY_CITY_1, TEST_ITINERARY_MAXBUDGET, TEST_ITINERARY_MAXDAYS, pageable);
 
-		assertTrue(expected.getNumberOfElements() == 1);
-		assertSame((long) expected.toList().get(0).getId(), TEST_ITINERARY_ID);
+		assertEquals(1,expected.getNumberOfElements());
+		assertSame(TEST_ITINERARY_ID, (long) expected.toList().get(0).getId());
 	}
 	
 	@Test
 	void testSearchByDistance() {
 		Page<ItineraryProjection> expected = this.itineraryService.searchByDistance(TEST_ITINERARY_LATITUDE, TEST_ITINERARY_LONGITUDE, this.pageable);
 
-		assertTrue(expected.getNumberOfElements() == 2);
-		assertSame((long) expected.toList().get(0).getId(), TEST_ITINERARY_ID);
-		assertSame((long) expected.toList().get(1).getId(), TEST_ITINERARY_ID_2);
+		assertEquals(2,expected.getNumberOfElements());
+		assertSame(TEST_ITINERARY_ID, (long) expected.toList().get(0).getId());
+		assertSame(TEST_ITINERARY_ID_2, (long) expected.toList().get(1).getId());
 	}
 	
 	@Test
 	void testSearchByName() {
 		Page<ItineraryProjection> expected = this.itineraryService.searchByName(this.pageable, TEST_ITINERARY_NAME);
 
-		assertTrue(expected.getNumberOfElements() == 1);
-		assertSame((long) expected.toList().get(0).getId(), TEST_ITINERARY_ID);
+		assertEquals(1,expected.getNumberOfElements());
+		assertSame(TEST_ITINERARY_ID, (long) expected.toList().get(0).getId());
 	}
 	
 	@Test
 	void testSearchByUsername() {
 		Page<ItineraryProjection> expected = this.itineraryService.searchByUsername(this.pageable, TEST_ITINERARY_USERNAME);
 
-		assertTrue(expected.getNumberOfElements() == 1);
-		assertSame((long) expected.toList().get(0).getId(), TEST_ITINERARY_ID);
+		assertEquals(1,expected.getNumberOfElements());
+		assertSame(TEST_ITINERARY_ID,(long) expected.toList().get(0).getId());
 	}
 	
 	@Test
 	void testSearchByCurrentUsername() {
 		Page<ItineraryProjection> expected = this.itineraryService.searchByCurrentUsername(this.pageable, TEST_ITINERARY_USERNAME);
 
-		assertTrue(expected.getNumberOfElements() == 1);
-		assertSame((long) expected.toList().get(0).getId(), TEST_ITINERARY_ID);
+		assertEquals(1,expected.getNumberOfElements());
+		assertSame(TEST_ITINERARY_ID,(long) expected.toList().get(0).getId());
 	}
 	
 	@Test

--- a/src/test/java/com/yourney/service/LandmarkServiceTests.java
+++ b/src/test/java/com/yourney/service/LandmarkServiceTests.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 
@@ -188,7 +189,7 @@ class LandmarkServiceTests {
 
 		Boolean expected = this.landmarkService.existsActivityByLandmarkId(LandmarkServiceTests.TEST_LANDMARK_ID1);
 
-		assertSame(expected, true);
+		assertSame(true, expected);
 	}
 	
 	@Test
@@ -196,7 +197,7 @@ class LandmarkServiceTests {
 
 		Boolean expected = this.landmarkService.existsActivityByLandmarkId(LandmarkServiceTests.TEST_LANDMARK_ID_NOT_FOUND);
 
-		assertSame(expected, false);
+		assertSame(false, expected);
 	}
 	
 	@Test
@@ -206,7 +207,7 @@ class LandmarkServiceTests {
 		List<Landmark> result = new ArrayList<Landmark>();
 		expected.forEach(result::add);
 
-		assertTrue(result.size() == 2);
+		assertEquals(2,result.size());
 		assertSame(result.get(0), this.l1);
 		assertSame(result.get(1), this.landmarkCreado);
 	}
@@ -219,8 +220,8 @@ class LandmarkServiceTests {
 		List<String> result = new ArrayList<String>();
 		expected.forEach(result::add);
 		
-		assertTrue(result.size() == 1);
-		assertSame(result.get(0), "España");
+		assertEquals(1,result.size());
+		assertSame("España", result.get(0));
 	}
 	
 	@Test
@@ -231,8 +232,8 @@ class LandmarkServiceTests {
 		List<String> result = new ArrayList<String>();
 		expected.forEach(result::add);
 		
-		assertTrue(result.size() == 1);
-		assertSame(result.get(0), "Sevilla");
+		assertEquals(1,result.size());
+		assertSame("Sevilla",result.get(0));
 	}
 	
 	@Test
@@ -243,8 +244,8 @@ class LandmarkServiceTests {
 		List<String> result = new ArrayList<String>();
 		expected.forEach(result::add);
 		
-		assertTrue(result.size() == 1);
-		assertSame(result.get(0), "Sevilla");
+		assertEquals(1,result.size());
+		assertSame("Sevilla",result.get(0));
 	}
 	
 	@Test


### PR DESCRIPTION
- Refactorización del código relacionado con las pruebas para evitar malos olores e implementaciones ineficientes.
- Se ha procedido a añadir la posibilidad de obtener resultados ignorando letras mayúsculas o minúsculas al realizar una búsqueda.

Tarea relacionada: #109 