### PR TITLE
HotFix: Configuración de despliegue para el Sprint 2

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,5 +41,5 @@ cloudinary.api-secret = hzmrxh1a6Vt33FWUznHfOBTA0fM
 paypal.mode = sandbox
 paypal.client.app = AZF9TaqBA5RXlJpjJ3HWGJYznw3Smzuul72FxNzwFbXsUON7EBegk6j0fUgj3J3r-FCWRz_wqyBxnj2e
 paypal.client.secret = ECBdIE9idu7FanWLx6LEnHVp8c_NBMLVZ1-12_qmF3oZWoeGR_fXwUnu5tU-_OaKxMUnsRtgdjuZcIwM
-paypal.callback-url = https://be-dev-yourney.herokuapp.com
-paypal.frontend-url = https://fe-dev-yourney.herokuapp.com
+paypal.callback-url = https://be-s2-yourney.herokuapp.com
+paypal.frontend-url = https://fe-s2-yourney.herokuapp.com


### PR DESCRIPTION
Se ha cambiado la URL de callback de la API de PayPal para que apunte a la configuración de despliegue.

Tarea relacionada: #73