### PR TITLE
Cambiado itinerary proyection

### DIFF
--- a/src/main/java/com/yourney/model/projection/ItineraryProjection.java
+++ b/src/main/java/com/yourney/model/projection/ItineraryProjection.java
@@ -23,4 +23,9 @@ public interface ItineraryProjection {
     Double getAvgRating();
     
     Long getCountComments();
+    
+	Integer getCalcPlan();
+
+	long getCalcPromotion();
+
 }

--- a/src/main/java/com/yourney/model/projection/ItineraryProjection.java
+++ b/src/main/java/com/yourney/model/projection/ItineraryProjection.java
@@ -26,6 +26,6 @@ public interface ItineraryProjection {
     
 	Integer getCalcPlan();
 
-	long getCalcPromotion();
+	Long getCalcPromotion();
 
 }


### PR DESCRIPTION
Se ha cambiado itinerary proyection para que tambien englobe los atributos calcPlan y calcPromotion de itinerary. Tras dicho cambio se mostraban los atributos en los json a enviar sin necesidad de modificar las querys.