### PR TITLE
Eliminación de visitas de itinerarios y puntos de interés

### DIFF
--- a/src/main/java/com/yourney/controller/ItineraryController.java
+++ b/src/main/java/com/yourney/controller/ItineraryController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
@@ -274,6 +275,10 @@ public class ItineraryController {
 				return ResponseEntity.status(HttpStatus.FORBIDDEN)
 						.body(new Message("No puede borrar un itinerario que no es suyo"));
 			} else {
+				if (itinerary.getViews()>0) {
+					List<ItineraryVisit> visitsItineraryToDelete = itineraryVisitService.findAllVisitsByItinerary(itinerary);
+					visitsItineraryToDelete.stream().forEach(v-> itineraryVisitService.delete(v));
+				}
 				itinerary.getActivities().stream().forEach(a -> activityService.deleteById(a.getId()));
 				itineraryService.deleteById(id);
 			}

--- a/src/main/java/com/yourney/controller/LandmarkController.java
+++ b/src/main/java/com/yourney/controller/LandmarkController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
@@ -123,6 +124,11 @@ public class LandmarkController {
         if (existsActivityFromLandmark) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(new Message("El punto de interés se encuentra asociado con al menos una actividad."));
+        }
+
+        if (landmarkToDelete.getViews()>0) {
+            List<LandmarkVisit> visitsLandmarkToDelete = landmarkVisitService.findAllVisitsByLandmark(landmarkToDelete);
+            visitsLandmarkToDelete.stream().forEach(v-> landmarkVisitService.delete(v));
         }
 
         landmarkService.deleteById(landmarkToDelete.getId());

--- a/src/main/java/com/yourney/model/LandmarkVisit.java
+++ b/src/main/java/com/yourney/model/LandmarkVisit.java
@@ -1,6 +1,5 @@
 package com.yourney.model;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/src/main/java/com/yourney/model/LandmarkVisit.java
+++ b/src/main/java/com/yourney/model/LandmarkVisit.java
@@ -1,5 +1,6 @@
 package com.yourney.model;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/src/main/java/com/yourney/repository/ItineraryVisitRepository.java
+++ b/src/main/java/com/yourney/repository/ItineraryVisitRepository.java
@@ -1,5 +1,7 @@
 package com.yourney.repository;
 
+import java.util.List;
+
 import com.yourney.model.ItineraryVisit;
 
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +15,6 @@ public interface ItineraryVisitRepository extends CrudRepository<ItineraryVisit,
 @Query("select case when count(lv)> 0 then true else false end from ItineraryVisit lv where lv.itinerary.id = :itineraryId and lv.ip = :direccionIp")
 Boolean comprobarExistenciaIpEnItinerario(@Param("itineraryId") Long itineraryId, @Param("direccionIp") String direccionIp);
 
+@Query("select v from ItineraryVisit v where v.itinerary.id = :itineraryIdentifier")
+List<ItineraryVisit> findAllVisitsByItineraryId(@Param("itineraryIdentifier") Long itineraryId);
 }

--- a/src/main/java/com/yourney/repository/LandmarkVisitRepository.java
+++ b/src/main/java/com/yourney/repository/LandmarkVisitRepository.java
@@ -1,5 +1,7 @@
 package com.yourney.repository;
 
+import java.util.List;
+
 import com.yourney.model.LandmarkVisit;
 
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +15,6 @@ public interface LandmarkVisitRepository extends CrudRepository<LandmarkVisit, L
 @Query("select case when count(lv)> 0 then true else false end from LandmarkVisit lv where lv.landmark.id = :landmarkId and lv.ip = :direccionIp")
 Boolean comprobarExistenciaIpEnLandmark(@Param("landmarkId") Long landmarkId, @Param("direccionIp") String direccionIp);
 
+@Query("select v from LandmarkVisit v where v.landmark.id = :landmarkIdentifier")
+List<LandmarkVisit> findAllVisitsByLandmarkId(@Param("landmarkIdentifier") Long landmarkId);
 }

--- a/src/main/java/com/yourney/service/ItineraryVisitService.java
+++ b/src/main/java/com/yourney/service/ItineraryVisitService.java
@@ -1,7 +1,9 @@
 package com.yourney.service;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.yourney.model.Itinerary;
 import com.yourney.model.ItineraryVisit;
 import com.yourney.repository.ItineraryVisitRepository;
 
@@ -30,5 +32,18 @@ public class ItineraryVisitService {
             e.printStackTrace();
         }
         return newLvisit;
+    }
+
+    public void delete(ItineraryVisit ivisit) {
+        try {
+            itineraryVisitRepository.delete(ivisit);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public List<ItineraryVisit> findAllVisitsByItinerary(Itinerary itinerary) {
+        Long identificadorItinerary = itinerary.getId();
+        return itineraryVisitRepository.findAllVisitsByItineraryId(identificadorItinerary);
     }
 }

--- a/src/main/java/com/yourney/service/LandmarkVisitService.java
+++ b/src/main/java/com/yourney/service/LandmarkVisitService.java
@@ -44,7 +44,6 @@ public class LandmarkVisitService {
 
     public List<LandmarkVisit> findAllVisitsByLandmark(Landmark landmark) {
         Long identificadorLandmark = landmark.getId();
-        System.out.println(identificadorLandmark);
         return landmarkVisitRepository.findAllVisitsByLandmarkId(identificadorLandmark);
     }
 }

--- a/src/main/java/com/yourney/service/LandmarkVisitService.java
+++ b/src/main/java/com/yourney/service/LandmarkVisitService.java
@@ -1,7 +1,9 @@
 package com.yourney.service;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.yourney.model.Landmark;
 import com.yourney.model.LandmarkVisit;
 import com.yourney.repository.LandmarkVisitRepository;
 
@@ -30,5 +32,19 @@ public class LandmarkVisitService {
             e.printStackTrace();
         }
         return newLvisit;
+    }
+
+    public void delete(LandmarkVisit lvisit) {
+        try {
+            landmarkVisitRepository.delete(lvisit);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public List<LandmarkVisit> findAllVisitsByLandmark(Landmark landmark) {
+        Long identificadorLandmark = landmark.getId();
+        System.out.println(identificadorLandmark);
+        return landmarkVisitRepository.findAllVisitsByLandmarkId(identificadorLandmark);
     }
 }


### PR DESCRIPTION
Se ha procedido a eliminar un error que impedía eliminar un itinerario con visitas asociadas, ya que se impedía eliminarlo por una restricción de clave foránea.
Corregido error relacionado con las visitas de los puntos de interés, que generaban conflicto al ser eliminado el punto de interés al que hacen referencia, creando un error en la aplicación.

Tarea relacionada: #163 